### PR TITLE
Add logic to return 'console' when 'config.debug' is defined

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -7,6 +7,7 @@ module.exports = {
   host: process.env.HOST || '0.0.0.0',
   errorEmails: process.env.ERROR_EMAILS || '',
   hashModule: process.env.CRYPTO_ALG || 'OWN_HASH',
+  debug: process.env.DEBUG || false,
 
   development: {
     username: process.env.SEQUELIZE_USER || 'root',

--- a/config/default.js
+++ b/config/default.js
@@ -7,7 +7,7 @@ module.exports = {
   host: process.env.HOST || '0.0.0.0',
   errorEmails: process.env.ERROR_EMAILS || '',
   hashModule: process.env.CRYPTO_ALG || 'OWN_HASH',
-  debug: process.env.DEBUG || false,
+  debug_logger: process.env.DEBUG_LOGGER || false,
 
   development: {
     username: process.env.SEQUELIZE_USER || 'root',

--- a/src/services/winston/logger.js
+++ b/src/services/winston/logger.js
@@ -4,7 +4,7 @@
 
 const config = require('config');
 
-if (config.debug) {
+if (config.debug_logger) {
   module.exports = console;
 } else {
   const winston = require('winston');

--- a/src/services/winston/logger.js
+++ b/src/services/winston/logger.js
@@ -1,44 +1,52 @@
 'use strict';
 
-const appRoot = require('app-root-path');
-const winston = require('winston');
-const SendGridTransport = require('./sendgrid-transport');
+/* eslint-disable global-require */
 
-const opt = {
-  file: {
-    level: 'info',
-    filename: `${appRoot}/logs/app.log`,
-    handleExceptions: true,
-    json: true,
-    maxsize: 5 * 1024 * 1024, // 5MB
-    maxFiles: 5,
-    colorize: false,
-  },
-  console: {
-    level: 'debug',
-    handleExceptions: true,
-    json: false,
-    colorize: true,
-  },
-  sendgrid: {
-    level: 'error',
-  },
-};
+const config = require('config');
 
-const logger = winston.createLogger({
-  transports: [
-    new winston.transports.File(opt.file),
-    new winston.transports.Console(opt.console),
-    new SendGridTransport(opt.sendgrid),
-  ],
-  exitOnError: false,
-});
+if (config.debug) {
+  module.exports = console;
+} else {
+  const winston = require('winston');
+  const appRoot = require('app-root-path');
+  const SendGridTransport = require('./sendgrid-transport');
 
-logger.stream = {
-  // eslint-disable-next-line no-unused-vars
-  write(message, encoding) {
-    logger.log('info', message);
-  },
-};
+  const opt = {
+    file: {
+      level: 'info',
+      filename: `${appRoot}/logs/app.log`,
+      handleExceptions: true,
+      json: true,
+      maxsize: 5 * 1024 * 1024, // 5MB
+      maxFiles: 5,
+      colorize: false,
+    },
+    console: {
+      level: 'debug',
+      handleExceptions: true,
+      json: false,
+      colorize: true,
+    },
+    sendgrid: {
+      level: 'error',
+    },
+  };
 
-module.exports = logger;
+  const logger = winston.createLogger({
+    transports: [
+      new winston.transports.File(opt.file),
+      new winston.transports.Console(opt.console),
+      new SendGridTransport(opt.sendgrid),
+    ],
+    exitOnError: false,
+  });
+
+  logger.stream = {
+    // eslint-disable-next-line no-unused-vars
+    write(message, encoding) {
+      logger.log('info', message);
+    },
+  };
+
+  module.exports = logger;
+}


### PR DESCRIPTION
Because errors printed in console by winston have no message and we only need winston in production